### PR TITLE
Stop reloading when in non-graphical target

### DIFF
--- a/gswitch
+++ b/gswitch
@@ -28,6 +28,12 @@ ask_reload() {
 }
 
 do_reload() {
+  DEF_TARGET=$(systemctl get-default)
+  CUR_TARGET=$(systemctl list-units --type target | egrep "^eme|^res|^gra|^mul" | head -1 | awk '{print $1}')
+  if [ "${CUR_TARGET}" != "${DEF_TARGET}" ]; then
+     echo "Non-graphical/non-default mode: Switch not performed"
+     exit 0
+  fi
   ( trap '' HUP TERM
     while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
       = "active" ]; do

--- a/gswitch
+++ b/gswitch
@@ -28,12 +28,6 @@ ask_reload() {
 }
 
 do_reload() {
-  DEF_TARGET=$(systemctl get-default)
-  CUR_TARGET=$(systemctl list-units --type target | egrep "^eme|^res|^gra|^mul" | head -1 | awk '{print $1}')
-  if [ "${CUR_TARGET}" != "${DEF_TARGET}" ]; then
-     echo "Non-graphical/non-default mode: Switch not performed"
-     exit 0
-  fi
   ( trap '' HUP TERM
     while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
       = "active" ]; do

--- a/gswitch.service
+++ b/gswitch.service
@@ -5,4 +5,4 @@ Description=Automatic GPU switching service
 ExecStart=/usr/bin/gswitch boot
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=graphical.target


### PR DESCRIPTION
Previous version would automatically reload to default (usually graphical) target when booting or manually switching. This caused problems when trying to boot to a non-default target such as a multi-user text console. This is updated so that the user is informed switching will not be done when in the non-default (usually text console or some such) target. Open to ideas on if/how this could be done better.