### PR TITLE
Check for a Display when Using Open Source Drivers

### DIFF
--- a/gswitch
+++ b/gswitch
@@ -69,9 +69,10 @@ switch_egpu() {
     DISP_PATH=/sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status
     DISP_NUM=$(ls ${DISP_PATH} | grep -c status)
     if [ $(cat ${DISP_PATH} | grep -ce ^disconnected$) -eq $DISP_NUM ] && [ $DISP_NUM -gt 0 ]; then
-      echo "Warning: No eGPU attached display detected with open source drivers"
-      echo "Internal mode and setting DRI_PRIME variable are recommended for this configuration"
+      echo "Warning: No eGPU attached display detected with open source drivers."
+      echo "Internal mode and setting DRI_PRIME variable are recommended for this configuration."
       echo "Not setting eGPU mode."
+      switch_internal
       exit 0
     fi
   fi

--- a/gswitch
+++ b/gswitch
@@ -9,6 +9,14 @@ EGPU_TEMPLATE="/etc/X11/xorg.conf.egpu"
 EGPU_BUS_ID=$(awk '/BusID/{gsub(/(PCI:|\")/," ");print$2}' < ${EGPU_TEMPLATE})
 XORG_DRIVER=$(awk '/Driver/{gsub("\"","");print$2}' < ${EGPU_TEMPLATE})
 
+if [ -h /etc/X11/xorg.conf ] && \
+   [ -f /etc/X11/xorg.conf.egpu ] && \
+   [ "$(readlink /etc/X11/xorg.conf)" = "/etc/X11/xorg.conf.egpu" ]; then
+  EGPU_SET="true"
+else
+  EGPU_SET="false"
+fi
+
 ask_reload() {
   QUESTION=$1
   echo "${QUESTION}"
@@ -45,9 +53,33 @@ do_reload() {
 }
 
 switch_egpu() {
-  if [ -h /etc/X11/xorg.conf ] && \
-     [ -f /etc/X11/xorg.conf.egpu ] && \
-     [ "$(readlink /etc/X11/xorg.conf)" = "/etc/X11/xorg.conf.egpu" ]; then
+  if [ ${XORG_DRIVER} != "nvidia" ]; then
+    for HEX_ID in $(lspci | grep -i 'vga' | cut -f 1 -d ' '); do
+      DEC_ID=""
+      for HEX_VALUE in $(echo ${HEX_ID} | tr ':|\.' ' '); do
+        HEX_VALUE_UPPER=$(echo ${HEX_VALUE} | tr '[a-z]' '[A-Z]')
+        DEC_VALUE=$(echo "ibase=16; ${HEX_VALUE_UPPER}" | bc)
+        DEC_ID="${DEC_ID}:${DEC_VALUE}"
+      done
+      DEC_ID=$(echo ${DEC_ID} | sed 's/^://')
+      if [ "${DEC_ID}" = "${EGPU_BUS_ID}" ]; then
+        break
+      fi
+    done
+    DISPLAY_ON="false"
+    for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/enabled); do
+      if [ ${DISP} = "enabled" ]; then
+        DISPLAY_ON="true"
+      fi
+    done
+    if [ ${DISPLAY_ON} = "false" ]; then
+      echo "Warning: No eGPU attached display detected with open source drivers"
+      echo "Internal mode and setting DRI_PRIME variable are recommended for this configuration"
+      echo "Not setting eGPU mode."
+      exit 0
+    fi
+  fi
+  if [ "${EGPU_SET}" = "true" ]; then
     ask_reload "You are already set up. Would you like to reload? (Y/n)"
     if [ ${RELOAD} = "true" ]; then
       do_reload
@@ -66,9 +98,7 @@ switch_egpu() {
 }
 
 switch_internal() {
-  if [ -h /etc/X11/xorg.conf ] && \
-     [ -f /etc/X11/xorg.conf.egpu ] && \
-     [ "$(readlink /etc/X11/xorg.conf)" = "/etc/X11/xorg.conf.egpu" ]; then
+  if [ "${EGPU_SET}" = "true" ]; then
     rm -f /etc/X11/xorg.conf
     ask_reload "You are now set up. Would you like to reload? (Y/n)"
     if [ ${RELOAD} = "true" ]; then
@@ -115,10 +145,18 @@ case $1 in
     done
     case ${MODE} in
       egpu)
-        yes | switch_egpu
+        if [ "${EGPU_SET}" = "true" ]; then
+          echo "no" | switch_egpu
+	else
+          echo "yes" | switch_egpu
+        fi
       ;;
       internal)
-        yes | switch_internal
+        if [ "${EGPU_SET}" = "true" ]; then
+          echo "yes" | switch_internal
+        else
+          echo "no" | switch_internal
+        fi
       ;;
     esac
   ;;

--- a/gswitch
+++ b/gswitch
@@ -66,13 +66,9 @@ switch_egpu() {
         break
       fi
     done
-    DISPLAY_ON="false"
-    for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status); do
-      if [ ${DISP} = "connected" ]; then
-        DISPLAY_ON="true"
-      fi
-    done
-    if [ ${DISPLAY_ON} = "false" ]; then
+    DISP_PATH=/sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status
+    DISP_NUM=$(ls ${DISP_PATH} | grep -c status)
+    if [ $(cat ${DISP_PATH} | grep -ce ^disconnected$) -eq $DISP_NUM ] && [ $DISP_NUM -gt 0 ]; then
       echo "Warning: No eGPU attached display detected with open source drivers"
       echo "Internal mode and setting DRI_PRIME variable are recommended for this configuration"
       echo "Not setting eGPU mode."

--- a/gswitch
+++ b/gswitch
@@ -67,8 +67,8 @@ switch_egpu() {
       fi
     done
     DISPLAY_ON="false"
-    for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/enabled); do
-      if [ ${DISP} = "enabled" ]; then
+    for DISP in $(cat /sys/bus/pci/devices/0000:${HEX_ID}/drm/card[0-9]*/card[0-9]*-*/status); do
+      if [ ${DISP} = "connected" ]; then
         DISPLAY_ON="true"
       fi
     done


### PR DESCRIPTION
Currently, the eGPU mode works well for all cards when a display is connected to the eGPU and also works when looping back to the internal display on nvidia cards with proprietary drivers and nvidia-prime. For amd cards or nvidia cards using the nouveau driver, trying to use the eGPU mode with the internal display only causes lagging or black screens. These changes check for non-nvidia drivers, then check the display outputs of the eGPU to see if any are connected. If not, it stops loading of the eGPU mode and prompts the user to use the DRI_PRIME environment variable.

I'm not sure if the user prompt is the best method, but I figured it would be the easiest to deal with. I tested with both amd and nvidia cards but only using an HDMI display. Checking the displayport/DVI behavior might be a good idea.