### PR TITLE
Change user prompt to adhere to prompt conventions

### DIFF
--- a/gswitch
+++ b/gswitch
@@ -77,7 +77,7 @@ switch_egpu() {
     fi
   fi
   if [ "${EGPU_SET}" = "true" ]; then
-    ask_reload "You are already set up. Would you like to reload? (Y/n)"
+    ask_reload "You are already set up. Would you like to reload? (yes/no)"
     if [ ${RELOAD} = "true" ]; then
       do_reload
     else
@@ -85,7 +85,7 @@ switch_egpu() {
     fi
   else
     ln -s /etc/X11/xorg.conf.egpu /etc/X11/xorg.conf
-    ask_reload "You are now set up. Would you like to reload? (Y/n)"
+    ask_reload "You are now set up. Would you like to reload? (yes/no)"
     if [ ${RELOAD} = "true" ]; then
       do_reload
     else
@@ -97,14 +97,14 @@ switch_egpu() {
 switch_internal() {
   if [ "${EGPU_SET}" = "true" ]; then
     rm -f /etc/X11/xorg.conf
-    ask_reload "You are now set up. Would you like to reload? (Y/n)"
+    ask_reload "You are now set up. Would you like to reload? (yes/no)"
     if [ ${RELOAD} = "true" ]; then
       do_reload
     else
       exit 0
     fi
   else
-    ask_reload "You are already set up. Would you like to reload? (Y/n)"
+    ask_reload "You are already set up. Would you like to reload? (yes/no)"
     if [ ${RELOAD} = "true" ]; then
       do_reload
     else


### PR DESCRIPTION
I believe the letter 'Y' should not be capitalized since that suggests
it being the default (just pressed Enter) action of the prompt.

Multiple tools in the UNIX world (apt, pacman) capitalize the default
action in these prompts. Then there are tools like ssh which do not
capitalize any options and don't have a default. This commit makes this
tool's prompts look similar to those of the ssh utility while not
suggesting there is a default option.

Closes #7