### PR TITLE
Add function to remove eGPU

### DIFF
--- a/gswitch
+++ b/gswitch
@@ -42,10 +42,21 @@ do_reload() {
       sleep 1
     done
     if [ ${XORG_DRIVER} = "nvidia" ]; then
+      systemctl stop nvidia-persistenced.service
+      if [ $(lsmod | grep "nvidia_uvm " | awk '{print $3}') -gt 0 ] || [ $(lsmod | grep "nvidia_drm " | awk '{print $3}') -gt 0 ]; then
+        systemctl start display-manager.service
+        echo "Driver still in use. Check for applications like Folding@Home running in the background. Stopping removal."
+        exit 0
+      fi
       for DRIVER in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
         modprobe -r ${DRIVER}
       done
     else
+      if [ $(lsmod | grep "${XORG_DRIVER} " | awk '{print $3}') -gt 0 ]; then
+        systemctl start display-manager.service
+        echo "Driver still in use. Check for applications like Folding@Home running in the background. Stopping removal."
+        exit 0
+      fi
       modprobe -r ${XORG_DRIVER}
     fi
     if [ ${REMOVE} = "true" ]; then
@@ -57,6 +68,9 @@ do_reload() {
     fi
     if [ $(lspci -k | grep -c ${XORG_DRIVER}) -gt 0 ]; then
       modprobe $XORG_DRIVER
+      if [ ${XORG_DRIVER} = "nvidia" ]; then
+        modprobe nvidia_drm
+      fi
     fi
     systemctl start display-manager.service ) &
   systemctl stop display-manager.service

--- a/gswitch
+++ b/gswitch
@@ -8,7 +8,6 @@ fi
 EGPU_TEMPLATE="/etc/X11/xorg.conf.egpu"
 EGPU_BUS_ID=$(awk '/BusID/{gsub(/(PCI:|\")/," ");print$2}' < ${EGPU_TEMPLATE})
 XORG_DRIVER=$(awk '/Driver/{gsub("\"","");print$2}' < ${EGPU_TEMPLATE})
-F1=$1
 
 if [ -h /etc/X11/xorg.conf ] && \
    [ -f /etc/X11/xorg.conf.egpu ] && \
@@ -37,46 +36,29 @@ ask_reload() {
 }
 
 do_reload() {
-  if [ $F1 = "internal" ]; then
-    BUS1D=$(echo $EGPU_BUS_ID | cut -f 1 -d :)
-    BUS2D=$(echo $EGPU_BUS_ID | cut -f 2 -d :)
-    BUS1H=$(printf "%02x" $BUS1D)
-    BUS2H=$(printf "%02x" $BUS2D)
-    HEX_DID=$(echo $BUS1H:$BUS2H.)
-    DEV_PATH=/sys/bus/pci/devices/[0-9a-f:]*${HEX_DID}[0-9]*/remove
-    if [ $(lspci -k | grep -A 3 ${HEX_DID} | grep -c "nvidia") -gt 0 ]; then
-      VGA_DRIVER=nvidia
-    elif [ $(lspci -k | grep -A 3 ${HEX_DID} | grep -c "amdgpu") -gt 0 ]; then
-      VGA_DRIVER=amdgpu
-    else
-      echo "Neither Nvidia or AMD GPU found at Bus ID specified in xorg.conf.egpu"
-      exit 1
-    fi
-    ( trap '' HUP TERM
-      while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
-        = "active" ]; do
-        sleep 1
+ ( trap '' HUP TERM
+    while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
+      = "active" ]; do
+      sleep 1
+    done
+    if [ ${XORG_DRIVER} = "nvidia" ]; then
+      for DRIVER in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
+        modprobe -r ${DRIVER}
       done
-      if [ ${VGA_DRIVER} = "nvidia" ]; then
-        for DRIVER in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
-          modprobe -r ${DRIVER}
-        done
-      else
-        modprobe -r ${VGA_DRIVER}
-      fi
+    else
+      modprobe -r ${XORG_DRIVER}
+    fi
+    if [ ${REMOVE} = "true" ]; then
       for PATH_D in ${DEV_PATH}; do
         if [ -e $PATH_D ]; then
           echo 1 > $PATH_D
         fi
       done
-      modprobe $VGA_DRIVER
-      systemctl start display-manager.service ) &
-    systemctl stop display-manager.service
-    exit 0
-  else
-    systemctl restart display-manager.service
-    exit 0
-  fi
+    fi
+    modprobe $XORG_DRIVER
+    systemctl start display-manager.service ) &
+  systemctl stop display-manager.service
+  exit 0
 }
 
 switch_egpu() {
@@ -142,7 +124,7 @@ switch_internal() {
 
 case $1 in
   -h|help)
-    echo "Valid arguments are \"egpu\", \"internal\", \"boot\" or \"setup\"."
+    echo "Valid arguments are \"egpu\", \"internal\", \"boot\", \"remove\" or \"setup\"."
     echo "Example: sudo gswitch egpu"
     exit 0
   ;;
@@ -183,6 +165,29 @@ case $1 in
         fi
       ;;
     esac
+  ;;
+  remove)
+    BUS1D=$(echo $EGPU_BUS_ID | cut -f 1 -d :)
+    BUS2D=$(echo $EGPU_BUS_ID | cut -f 2 -d :)
+    BUS1H=$(printf "%02x" $BUS1D)
+    BUS2H=$(printf "%02x" $BUS2D)
+    HEX_DID=$(echo $BUS1H:$BUS2H.)
+    DEV_PATH=/sys/bus/pci/devices/[0-9a-f:]*${HEX_DID}[0-9]*/remove
+    echo "Try removing the GPU PCIe addresses? This will switch to internal and log you out. (Beta) (Y/n): "
+    read REMOVE_ANSWER
+    case ${REMOVE_ANSWER} in
+      Y|y|Yes|yes)
+        REMOVE="true"
+      ;;
+      N|n|No|no)
+        REMOVE="false"
+      ;;
+      *)
+        echo "Unknown argument: ${REMOVE_ANSWER}."
+        exit 1
+      ;;
+    esac
+  echo "yes" | switch_internal
   ;;
   setup)
     cp /usr/share/gswitch/xorg.conf.egpu /etc/X11/xorg.conf.egpu

--- a/gswitch
+++ b/gswitch
@@ -8,6 +8,7 @@ fi
 EGPU_TEMPLATE="/etc/X11/xorg.conf.egpu"
 EGPU_BUS_ID=$(awk '/BusID/{gsub(/(PCI:|\")/," ");print$2}' < ${EGPU_TEMPLATE})
 XORG_DRIVER=$(awk '/Driver/{gsub("\"","");print$2}' < ${EGPU_TEMPLATE})
+F1=$1
 
 if [ -h /etc/X11/xorg.conf ] && \
    [ -f /etc/X11/xorg.conf.egpu ] && \
@@ -36,7 +37,7 @@ ask_reload() {
 }
 
 do_reload() {
-  if [ $F1 = "switch_internal" ]; then
+  if [ $F1 = "internal" ]; then
     BUS1D=$(echo $EGPU_BUS_ID | cut -f 1 -d :)
     BUS2D=$(echo $EGPU_BUS_ID | cut -f 2 -d :)
     BUS1H=$(printf "%02x" $BUS1D)
@@ -121,7 +122,6 @@ switch_egpu() {
 }
 
 switch_internal() {
-  F1="switch_internal"
   if [ "${EGPU_SET}" = "true" ]; then
     rm -f /etc/X11/xorg.conf
     ask_reload "You are now set up. Would you like to reload? (Y/n)"

--- a/gswitch
+++ b/gswitch
@@ -55,7 +55,9 @@ do_reload() {
         fi
       done
     fi
-    modprobe $XORG_DRIVER
+    if [ $(lspci -k | grep -c ${XORG_DRIVER}) -gt 0 ]; then
+      modprobe $XORG_DRIVER
+    fi
     systemctl start display-manager.service ) &
   systemctl stop display-manager.service
   exit 0

--- a/gswitch
+++ b/gswitch
@@ -36,7 +36,7 @@ ask_reload() {
 }
 
 do_reload() {
- ( trap '' HUP TERM
+  ( trap '' HUP TERM
     while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
       = "active" ]; do
       sleep 1
@@ -223,7 +223,7 @@ case $1 in
   ;;
   *)
     echo "Unknown argument: ${1}."
-    echo "Valid arguments are \"egpu\", \"internal\", \"boot\" or \"setup\"."
+    echo "Valid arguments are \"egpu\", \"internal\", \"boot\", \"remove\" or \"setup\"."
     echo "Example: sudo gswitch egpu"
     exit 1
   ;;

--- a/gswitch
+++ b/gswitch
@@ -36,20 +36,46 @@ ask_reload() {
 }
 
 do_reload() {
-  ( trap '' HUP TERM
-    while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
-      = "active" ]; do
-      sleep 1
-    done
-    if [ ${XORG_DRIVER} = "nvidia" ]; then
-      for DRIVER in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
-        modprobe -r ${DRIVER}
-      done
-      modprobe nvidia
+  if [ $F1 = "switch_internal" ]; then
+    BUS1D=$(echo $EGPU_BUS_ID | cut -f 1 -d :)
+    BUS2D=$(echo $EGPU_BUS_ID | cut -f 2 -d :)
+    BUS1H=$(printf "%02x" $BUS1D)
+    BUS2H=$(printf "%02x" $BUS2D)
+    HEX_DID=$(echo $BUS1H:$BUS2H.)
+    DEV_PATH=/sys/bus/pci/devices/[0-9a-f:]*${HEX_DID}[0-9]*/remove
+    if [ $(lspci -k | grep -A 3 ${HEX_DID} | grep -c "nvidia") -gt 0 ]; then
+      VGA_DRIVER=nvidia
+    elif [ $(lspci -k | grep -A 3 ${HEX_DID} | grep -c "amdgpu") -gt 0 ]; then
+      VGA_DRIVER=amdgpu
+    else
+      echo "Neither Nvidia or AMD GPU found at Bus ID specified in xorg.conf.egpu"
+      exit 1
     fi
-    systemctl start display-manager.service ) &
-  systemctl stop display-manager.service
-  exit 0
+    ( trap '' HUP TERM
+      while [ "$(systemctl status display-manager | awk '/Active:/{print$2}')" \
+        = "active" ]; do
+        sleep 1
+      done
+      if [ ${VGA_DRIVER} = "nvidia" ]; then
+        for DRIVER in nvidia_uvm nvidia_drm nvidia_modeset nvidia; do
+          modprobe -r ${DRIVER}
+        done
+      else
+        modprobe -r ${VGA_DRIVER}
+      fi
+      for PATH_D in ${DEV_PATH}; do
+        if [ -e $PATH_D ]; then
+          echo 1 > $PATH_D
+        fi
+      done
+      modprobe $VGA_DRIVER
+      systemctl start display-manager.service ) &
+    systemctl stop display-manager.service
+    exit 0
+  else
+    systemctl restart display-manager.service
+    exit 0
+  fi
 }
 
 switch_egpu() {
@@ -95,6 +121,7 @@ switch_egpu() {
 }
 
 switch_internal() {
+  F1="switch_internal"
   if [ "${EGPU_SET}" = "true" ]; then
     rm -f /etc/X11/xorg.conf
     ask_reload "You are now set up. Would you like to reload? (Y/n)"


### PR DESCRIPTION
This adds another function to the script called "remove" which stops the display manager, unloads the driver, removes the PCIe addresses of the eGPU, reloads the driver if necessary, then restarts the display manager. This is purely an enhancement. In my experience, this allows physically unplugging the eGPU anytime after the "remove" process completes. Without this, I would experience a system hang if the eGPU were unplugged. Let me know your experience with unplugging the eGPU, if this works for you or not, or if you have another way.

Note that AMD card users will see the following error message:
`[drm:amdgpu_pci_remove [amdgpu]] *ERROR* Device removal is currently not supported outside of fbcon`
Of the dozens of removals I've tried, I only had one error that required a hard reboot to solve. It seems like [patches](https://lists.freedesktop.org/archives/dri-devel/2020-May/265386.html) are in the works for better AMD removal (that might not even need restarting X). As it stands with the current kernels, all the steps I've added are strictly necessary for unplugging and they should remain the "safe" option even if better unplugging support comes later.

Also speaking of the kernel, I tried with a couple of old mainline kernels and found 5.0+ to be the requirement. Earlier ones did not work, but later worked fine on both the Linux Mint and Ubuntu systems I tested. Again, let me know what you think of this. I'd like to see it tested with more laptop configurations especially dGPU+eGPU. As it is I would consider this to be a "beta" feature that the user can call only if they want.